### PR TITLE
MySQL driver

### DIFF
--- a/src/main/java/net/coalcube/bansystem/core/util/MySQL.java
+++ b/src/main/java/net/coalcube/bansystem/core/util/MySQL.java
@@ -31,6 +31,13 @@ public class MySQL implements Database {
     }
 
     public void connect() throws SQLException {
+        try {
+            Class.forName("com.mysql.cj.jdbc.Driver");
+        } catch (ClassNotFoundException e) {
+            System.err.println("Fehler beim Laden des JDBC-Treibers");
+            e.printStackTrace();
+        }
+
         con = DriverManager.getConnection("jdbc:mysql://" + host + ":" + port + "/" + database + "?autoReconnect=true", username, password);
     }
 


### PR DESCRIPTION
Before creating a connection, load the mysql driver.
Otherwise there is an error "[main/INFO]: ┃ BanSystem » Debug Message: No suitable driver found for jdbc:mysql://localhost:3306/Bansystem?autoReconnect=true"
